### PR TITLE
New HTTP actions for the /nodes/ resource

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -259,13 +259,13 @@ paths:
       parameters:
       - name: name
         in: path
-        description: 'The hieradata level that needs to be fetched. Use node1 as the node name for testing. '
+        description: 'The hieradata level that needs to be fetched. Use node1 as the nodename for testing. '
         required: true
         schema:
           type: string
       - name: key
         in: path
-        description: 'The hieradata key that needs to be fetched. Use node1 as the node name & certname as the key for testing. '
+        description: 'The hieradata key that needs to be fetched. Use node1 as the nodename & certname as the key for testing. '
         required: true
         schema:
           type: string
@@ -281,6 +281,34 @@ paths:
           content: {}
         404:
           description: Node not found
+          content: {}
+    delete:
+      tags:
+      - nodes
+      summary: Deletes a hieradata
+      operationId: deleteHieradata
+      parameters:
+      - name: name
+        in: path
+        description: 'The hieradata that needs to be deleted. Use node1 as the nodename for testing. '
+        required: true
+        schema:
+          type: string
+      - name: key
+        in: path
+        description: 'The hieradata key that needs to be deleted. Use node1 as the nodename & certname as the key for testing. '
+        required: true
+        schema:
+          type: string
+      responses:
+        200:
+          description: Ok
+          content: {}
+        400:
+          description: Invalid Node name supplied
+          content: {}
+        404:
+          description: Nodedata not found
           content: {}
 
 components:


### PR DESCRIPTION
### Changes

Switching to node name instead of node ID. Also I'm introducing new HTTP actions (GET/POST/DELETE) for the following endpoints:

```
/nodes/{name}
/nodes/{name}/nodedata/
/nodes/{name}/hieradata/
/nodes/{name}/hieradata/{key}
```

#### Questions

Notice that I didn't add a DELETE action for `/nodes/{name}/hieradata/` I wanted to check with you if it's ok to remove all the `hieradata` associated with a node name?

Also the `GET /nodes/{name}/nodedata/` endpoint currently returns a single JSON object related to its Nodedata, but since we could have different `nodetada.code_environments` should we expect an array of `nodedata` instead?

#### Next actions

Once I validate that the new changes and questions make sense with you @reidmv I will add the PUT actions for the endpoints.
