### PR TITLE
Tidying up the 404 errors and the endpoints that support bulk operations

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -91,7 +91,7 @@ paths:
       tags:
         - users
       summary: Create a new user or replace an existing user
-      description: This can only be done by the logged in user.
+      description: If the username does not exist, it will create it for you. This endpoint does not support bulk operations
       operationId: putUser
       parameters:
         - $ref: "#/components/parameters/Username"
@@ -223,7 +223,7 @@ paths:
       tags:
         - nodes
       summary: Create a new node or replace an existing node
-      description: This can only be done by the logged in user.
+      description: If the node name does not exist, it will create it for you. This endpoint does not support bulk operations
       operationId: putNodeByName
       parameters:
         - $ref: "#/components/parameters/NodeName"
@@ -334,7 +334,7 @@ paths:
       tags:
         - hiera-data
       summary: Upserts a specific hiera object
-      description: Create/Update Hiera data using {level} and {key} as the identifier
+      description: If the hieradata with the compound ID {level} and {key} does not exist, it will create it for you. This endpoint does not support bulk operations
       operationId: upsertHieraDataWithLevelAndKey
       parameters:
         - $ref: "#/components/parameters/HieraLevel"


### PR DESCRIPTION
### Changes

1. I'm removing the HTTP 404 errors from the list of status codes returned by the PUT actions since we will create the resource if it does not exist.
2. I added a short description on the POST actions to explain to the user that these support bulk operations. I set a limit of 1,000 per transaction. This hard limit was set to avoid saying "you can send up to 2MB in size in the body params", also this implies that we will return up to 1,000 items in the response, which it's a lot of data, paginated it will be ± 40 pages of 25 items each. (Update: I know we will not paginate the responses in this first version)
3. Also added a short note on the PUT actions, explaining that we do not support bulk operations for PUTs