### PR TITLE
Create logger helper for DataAdapters

### DIFF
--- a/app/lib/pds/data_adapter/base.rb
+++ b/app/lib/pds/data_adapter/base.rb
@@ -42,6 +42,13 @@ module PDS
       def type
         raise NotImplementedError
       end
+
+      private
+
+      # @return [Logger]
+      def logger
+        PDSApp.logger
+      end
     end
   end
 end

--- a/app/lib/pds/data_adapter/mock.rb
+++ b/app/lib/pds/data_adapter/mock.rb
@@ -6,7 +6,7 @@ module PDS
   module DataAdapter
     class Mock < PDS::DataAdapter::Base
       def initialize(config)
-        PDSApp.logger.info 'Loading mock DataAdapter'
+        logger.info 'Loading mock DataAdapter'
         @data = sample_data
         true
       end
@@ -23,7 +23,7 @@ module PDS
       # @param filter [Array] an array of filters to apply
       # @return [Array] an array of resources
       def read(entity_type, filter: [])
-        PDSApp.logger.debug "Reading #{entity_type} with filter #{filter}"
+        logger.debug "Reading #{entity_type} with filter #{filter}"
 
         dat = @data[entity_type]
 


### PR DESCRIPTION
This centralizes where the logger comes from into the base class
definition so we can easily adjust or change it in the future if we
need to, as well as provides some nice syntactic sugar for the
implementing DataAdapters.