### PR TITLE
Fix up create migrations for primary keys

### DIFF
--- a/app/db/postgresql/migrate/20211208165831_create_users.rb
+++ b/app/db/postgresql/migrate/20211208165831_create_users.rb
@@ -1,14 +1,11 @@
 class CreateUsers < ActiveRecord::Migration[6.1]
   def change
-    create_table :users, id: false, primary_key: :username do |t|
-      t.string :username
+    create_table(:users, primary_key: :username) do |t|
       t.string :email
       t.string :role
       t.string :status
       t.string :temp_token
       t.timestamps
     end
-
-    add_index :users, :username, unique: true
   end
 end

--- a/app/db/postgresql/migrate/20211208171747_create_nodes.rb
+++ b/app/db/postgresql/migrate/20211208171747_create_nodes.rb
@@ -1,7 +1,6 @@
 class CreateNodes < ActiveRecord::Migration[6.1]
   def change
-    create_table :nodes, id: false, primary_key: :name do |t|
-      t.string :name
+    create_table(:nodes, primary_key: :name) do |t|
       t.string :code_environment
       t.jsonb :classes
       t.jsonb :trusted_data

--- a/app/db/postgresql/migrate/20211208172514_create_hieradata.rb
+++ b/app/db/postgresql/migrate/20211208172514_create_hieradata.rb
@@ -1,13 +1,12 @@
 class CreateHieradata < ActiveRecord::Migration[6.1]
   def change
-    create_table :hiera_data, id: false, primary_key: [:level, :key] do |t|
+    create_table(:hiera_data, primary_key: [:level, :key]) do |t|
       t.string :level
       t.string :key
       t.string :value
       t.timestamps
     end
 
-    add_index :hiera_data, [:level, :key], unique: true
     add_index :hiera_data, :level
     add_index :hiera_data, :key
   end

--- a/app/db/postgresql/schema.rb
+++ b/app/db/postgresql/schema.rb
@@ -26,19 +26,17 @@ ActiveRecord::Schema.define(version: 2021_12_08_173927) do
     t.index ["username"], name: "index_changelog_on_username"
   end
 
-  create_table "hiera_data", id: false, force: :cascade do |t|
-    t.string "level"
-    t.string "key"
+  create_table "hiera_data", primary_key: ["level", "key"], force: :cascade do |t|
+    t.string "level", null: false
+    t.string "key", null: false
     t.string "value"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["key"], name: "index_hiera_data_on_key"
-    t.index ["level", "key"], name: "index_hiera_data_on_level_and_key", unique: true
     t.index ["level"], name: "index_hiera_data_on_level"
   end
 
-  create_table "nodes", id: false, force: :cascade do |t|
-    t.string "name"
+  create_table "nodes", primary_key: "name", force: :cascade do |t|
     t.string "code_environment"
     t.jsonb "classes"
     t.jsonb "trusted_data"
@@ -46,15 +44,13 @@ ActiveRecord::Schema.define(version: 2021_12_08_173927) do
     t.datetime "updated_at", precision: 6, null: false
   end
 
-  create_table "users", id: false, force: :cascade do |t|
-    t.string "username"
+  create_table "users", primary_key: "username", force: :cascade do |t|
     t.string "email"
     t.string "role"
     t.string "status"
     t.string "temp_token"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.index ["username"], name: "index_users_on_username", unique: true
   end
 
 end


### PR DESCRIPTION
Took a little fiddling, but I think this is the right syntax for not
creating an "id" column, and for having the correct primary key(s).