### PR TITLE
Make node upsert work without flags

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -445,6 +445,7 @@ components:
       properties:
         code-environment:
           type: string
+          nullable: true
           description: Code environment
           enum:
             - staging

--- a/golang/pds-cli/cmd/node.go
+++ b/golang/pds-cli/cmd/node.go
@@ -108,10 +108,13 @@ var upsertNodeCmd = &cobra.Command{
 				Name : &name,
 			},
 			EditableNodeProperties : client.EditableNodeProperties{
-				CodeEnvironment : (*client.EditableNodePropertiesCodeEnvironment)(&codeEnvironment),
 				Classes : &classes,
 				TrustedData : &trustedData,
 			},
+		}
+
+		if codeEnvironment != "" {
+			body.CodeEnvironment = (*client.EditableNodePropertiesCodeEnvironment)(&codeEnvironment)
 		}
 
 		// Submit the request
@@ -147,5 +150,5 @@ func init() {
 	nodeCmd.AddCommand(upsertNodeCmd)
 	upsertNodeCmd.Flags().StringVarP(&codeEnvironment, "code-environment", "e", "", "Node code-environment")
 	upsertNodeCmd.Flags().StringSliceVarP(&classes, "classes", "c", []string{}, "Node classes (as comma-separated list)")
-	upsertNodeCmd.Flags().StringVarP(&trustedDataStr, "trusted-data", "d", "", "Node trusted data (as valid JSON object)")
+	upsertNodeCmd.Flags().StringVarP(&trustedDataStr, "trusted-data", "d", "{}", "Node trusted data (as valid JSON object)")
 }

--- a/golang/pkg/pds-go-client/api.gen.go
+++ b/golang/pkg/pds-go-client/api.gen.go
@@ -58,7 +58,7 @@ type EditableNodeProperties struct {
 	Classes *[]string `json:"classes,omitempty"`
 
 	// Code environment
-	CodeEnvironment *EditableNodePropertiesCodeEnvironment `json:"code-environment,omitempty"`
+	CodeEnvironment *EditableNodePropertiesCodeEnvironment `json:"code-environment"`
 	TrustedData     *map[string]interface{}                `json:"trusted-data,omitempty"`
 }
 


### PR DESCRIPTION
If the user doesn't supply values, all flags should default to the
correct "unset" versions of themselves.