### PR TITLE
loads lib/ folder from 1 single central location app.rb

### DIFF
--- a/app/Rakefile
+++ b/app/Rakefile
@@ -1,7 +1,3 @@
-# Enable easy use of `require` for content in lib/
-libdir = File.expand_path(File.join(__dir__, 'lib'))
-$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
-
 # Rakefile
 require 'sinatra/activerecord'
 require 'sinatra/activerecord/rake'

--- a/app/app.rb
+++ b/app/app.rb
@@ -1,3 +1,7 @@
+# Enable easy use of `require` for content in lib/
+libdir = File.expand_path(File.join(__dir__, 'lib'))
+$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
+
 require 'sinatra/base'
 require 'sinatra/custom_logger'
 require 'openapiing'

--- a/app/config.ru
+++ b/app/config.ru
@@ -1,6 +1,2 @@
-# Enable easy use of `require` for content in lib/
-libdir = File.expand_path(File.join(__dir__, 'lib'))
-$LOAD_PATH.unshift(libdir) unless $LOAD_PATH.include?(libdir)
-
 require './app'
 run App


### PR DESCRIPTION
### Changes

I'm centralizing the load of the `lib/` folder from app.rb, I tested this manually and starts the server without problems.

Another benefit is that we can use the Ruby interpreter to interact with our app.rb, super useful for debugging, testing and quick checks in development

```
bundle exec irb -I. -r app.rb

3.0.0 :002 > PDS::DataAdapter::PostgreSQL::User.count
D, [2021-12-17T18:40:47.594045 #88887] DEBUG -- :    (46.6ms)  SELECT COUNT(*) FROM "users"
 => 7
```

