### PR TITLE
Use name "Hiera Datum" in API spec

### DIFF
--- a/docs/api.yml
+++ b/docs/api.yml
@@ -98,7 +98,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/Username"
       requestBody:
-        $ref: "#/components/requestBodies/NewUser"
+        $ref: "#/components/requestBodies/EditableUserProperties"
       responses:
         "200":
           description: Updated
@@ -232,7 +232,7 @@ paths:
       parameters:
         - $ref: "#/components/parameters/NodeName"
       requestBody:
-        $ref: "#/components/requestBodies/NewNode"
+        $ref: "#/components/requestBodies/EditableNodeProperties"
       responses:
         "200":
           description: Updated
@@ -289,7 +289,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/HieraValue"
+                  $ref: "#/components/schemas/HieraDatum"
         "401":
           $ref: '#/components/responses/UnauthorizedError'
     post:
@@ -308,7 +308,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: "#/components/schemas/HieraValue"
+                  $ref: "#/components/schemas/HieraDatum"
         "400":
           description: '{"error": "Bad Request. Unable to create requested hiera-data, check for duplicate hiera-data"}'
         "401":
@@ -331,7 +331,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HieraValue"
+                $ref: "#/components/schemas/HieraDatum"
         "401":
           $ref: '#/components/responses/UnauthorizedError'
         "404":
@@ -346,20 +346,20 @@ paths:
         - $ref: "#/components/parameters/HieraLevel"
         - $ref: "#/components/parameters/HieraKey"
       requestBody:
-        $ref: "#/components/requestBodies/EditHieraValue"
+        $ref: "#/components/requestBodies/EditableHieraDatumProperties"
       responses:
         "200":
           description: Updated
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HieraValue"
+                $ref: "#/components/schemas/HieraDatum"
         "201":
           description: Created
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/HieraValue"
+                $ref: "#/components/schemas/HieraDatum"
         "400":
           description: '{"error": "Bad Request. Unable to create requested hiera-data, check for duplicate hiera-data"}'
         "401":
@@ -478,7 +478,7 @@ components:
         - $ref: "#/components/schemas/EditableNodeProperties"
         - $ref: "#/components/schemas/TimestampProperties"
 
-    ImmutableHieraValueProperties:
+    ImmutableHieraDatumProperties:
       type: object
       properties:
         level:
@@ -486,17 +486,17 @@ components:
         key:
           type: string
 
-    EditableHieraValueProperties:
+    EditableHieraDatumProperties:
       type: object
       properties:
         value:
           nullable: true
           description: The value to set the Hiera key to
 
-    HieraValue:
+    HieraDatum:
       allOf:
-        - $ref: "#/components/schemas/ImmutableHieraValueProperties"
-        - $ref: "#/components/schemas/EditableHieraValueProperties"
+        - $ref: "#/components/schemas/ImmutableHieraDatumProperties"
+        - $ref: "#/components/schemas/EditableHieraDatumProperties"
         - $ref: "#/components/schemas/TimestampProperties"
 
   parameters:
@@ -541,17 +541,16 @@ components:
         type: string
 
   requestBodies:
-    NewUser:
-      description: Create or edit user object
+    EditableUserProperties:
+      description: Editable properties of a user resource
       content:
         application/json:
           schema:
             allOf:
               - $ref: "#/components/schemas/EditableUserProperties"
-              - required: ["username"]
 
     NewUsers:
-      description: Create user object(s)
+      description: Create user resources
       content:
         application/json:
           schema:
@@ -562,17 +561,16 @@ components:
                 - $ref: "#/components/schemas/EditableUserProperties"
                 - required: ["username"]
 
-    NewNode:
-      description: Create or Edit node object
+    EditableNodeProperties:
+      description: Editable properties of a node resource
       content:
         application/json:
           schema:
             allOf:
               - $ref: "#/components/schemas/EditableNodeProperties"
-              - required: ["name"]
 
     NewNodes:
-      description: Create node object(s)
+      description: Create new node resources
       content:
         application/json:
           schema:
@@ -583,26 +581,27 @@ components:
                 - $ref: "#/components/schemas/EditableNodeProperties"
                 - required: ["name"]
 
+    EditableHieraDatumProperties:
+      description: Create or edit a Hiera value at a specified level and key
+      content:
+        application/json:
+          schema:
+            allOf:
+              - $ref: "#/components/schemas/EditableHieraDatumProperties"
+              - required: ["value"]
+
     NewHieraData:
-      description: Create new Hiera data value(s)
+      description: Create new Hiera data resources
       content:
         application/json:
           schema:
             type: array
             items:
               allOf:
-              - $ref: "#/components/schemas/ImmutableHieraValueProperties"
-              - $ref: "#/components/schemas/EditableHieraValueProperties"
+              - $ref: "#/components/schemas/ImmutableHieraDatumProperties"
+              - $ref: "#/components/schemas/EditableHieraDatumProperties"
               - required: ["level", "key", "value"]
 
-    EditHieraValue:
-      description: Create or edit a Hiera value at a specified level and key
-      content:
-        application/json:
-          schema:
-            allOf:
-              - $ref: "#/components/schemas/EditableHieraValueProperties"
-              - required: ["value"]
   responses:
     UnauthorizedError:
       description: Access (Bearer) token is missing or invalid

--- a/golang/pds-cli/cmd/hieradata.go
+++ b/golang/pds-cli/cmd/hieradata.go
@@ -106,9 +106,7 @@ var upsertHieraDataCmd = &cobra.Command{
 		}
 
 		body := client.UpsertHieraDataWithLevelAndKeyJSONRequestBody{
-			EditableHieraValueProperties : client.EditableHieraValueProperties{
-				Value : &value,
-			},
+			Value : &value,
 		}
 
 		response, err := pdsClient.UpsertHieraDataWithLevelAndKeyWithResponse(context.Background(), client.HieraLevel(levelStr), client.HieraKey(keyStr), body)

--- a/golang/pds-cli/cmd/node.go
+++ b/golang/pds-cli/cmd/node.go
@@ -102,10 +102,8 @@ var upsertNodeCmd = &cobra.Command{
 		}
 
 		body := client.PutNodeByNameJSONRequestBody{
-			EditableNodeProperties : client.EditableNodeProperties{
-				Classes : &classes,
-				Data : &data,
-			},
+			Classes : &classes,
+			Data : &data,
 		}
 
 		if codeEnvironment != "" {

--- a/golang/pds-cli/cmd/user.go
+++ b/golang/pds-cli/cmd/user.go
@@ -104,10 +104,8 @@ var upsertUserCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		// Build the JSON body
 		body := client.PutUserJSONRequestBody{
-			EditableUserProperties : client.EditableUserProperties{
-				Email : &userEmail,
-				Role : (*client.EditableUserPropertiesRole)(&userRole),
-			},
+			Email : &userEmail,
+			Role : (*client.EditableUserPropertiesRole)(&userRole),
 		}
 
 		// Submit the request

--- a/golang/pkg/pds-go-client/api.gen.go
+++ b/golang/pkg/pds-go-client/api.gen.go
@@ -47,8 +47,8 @@ const (
 	ReadOnlyUserPropertiesStatusInactive ReadOnlyUserPropertiesStatus = "inactive"
 )
 
-// EditableHieraValueProperties defines model for EditableHieraValueProperties.
-type EditableHieraValueProperties struct {
+// EditableHieraDatumProperties defines model for EditableHieraDatumProperties.
+type EditableHieraDatumProperties struct {
 	// The value to set the Hiera key to
 	Value *interface{} `json:"value"`
 }
@@ -76,18 +76,18 @@ type EditableUserProperties struct {
 // User role
 type EditableUserPropertiesRole string
 
-// HieraValue defines model for HieraValue.
-type HieraValue struct {
-	// Embedded struct due to allOf(#/components/schemas/ImmutableHieraValueProperties)
-	ImmutableHieraValueProperties `yaml:",inline"`
-	// Embedded struct due to allOf(#/components/schemas/EditableHieraValueProperties)
-	EditableHieraValueProperties `yaml:",inline"`
+// HieraDatum defines model for HieraDatum.
+type HieraDatum struct {
+	// Embedded struct due to allOf(#/components/schemas/ImmutableHieraDatumProperties)
+	ImmutableHieraDatumProperties `yaml:",inline"`
+	// Embedded struct due to allOf(#/components/schemas/EditableHieraDatumProperties)
+	EditableHieraDatumProperties `yaml:",inline"`
 	// Embedded struct due to allOf(#/components/schemas/TimestampProperties)
 	TimestampProperties `yaml:",inline"`
 }
 
-// ImmutableHieraValueProperties defines model for ImmutableHieraValueProperties.
-type ImmutableHieraValueProperties struct {
+// ImmutableHieraDatumProperties defines model for ImmutableHieraDatumProperties.
+type ImmutableHieraDatumProperties struct {
 	Key   *string `json:"key,omitempty"`
 	Level *string `json:"level,omitempty"`
 }
@@ -160,26 +160,12 @@ type NodeName string
 // OptionalHieraLevel defines model for OptionalHieraLevel.
 type OptionalHieraLevel string
 
-// EditHieraValue defines model for EditHieraValue.
-type EditHieraValue struct {
-	// Embedded struct due to allOf(#/components/schemas/EditableHieraValueProperties)
-	EditableHieraValueProperties `yaml:",inline"`
-	// Embedded fields due to inline allOf schema
-}
-
 // NewHieraData defines model for NewHieraData.
 type NewHieraData []struct {
-	// Embedded struct due to allOf(#/components/schemas/ImmutableHieraValueProperties)
-	ImmutableHieraValueProperties `yaml:",inline"`
-	// Embedded struct due to allOf(#/components/schemas/EditableHieraValueProperties)
-	EditableHieraValueProperties `yaml:",inline"`
-	// Embedded fields due to inline allOf schema
-}
-
-// NewNode defines model for NewNode.
-type NewNode struct {
-	// Embedded struct due to allOf(#/components/schemas/EditableNodeProperties)
-	EditableNodeProperties `yaml:",inline"`
+	// Embedded struct due to allOf(#/components/schemas/ImmutableHieraDatumProperties)
+	ImmutableHieraDatumProperties `yaml:",inline"`
+	// Embedded struct due to allOf(#/components/schemas/EditableHieraDatumProperties)
+	EditableHieraDatumProperties `yaml:",inline"`
 	// Embedded fields due to inline allOf schema
 }
 
@@ -189,13 +175,6 @@ type NewNodes []struct {
 	ImmutableNodeProperties `yaml:",inline"`
 	// Embedded struct due to allOf(#/components/schemas/EditableNodeProperties)
 	EditableNodeProperties `yaml:",inline"`
-	// Embedded fields due to inline allOf schema
-}
-
-// NewUser defines model for NewUser.
-type NewUser struct {
-	// Embedded struct due to allOf(#/components/schemas/EditableUserProperties)
-	EditableUserProperties `yaml:",inline"`
 	// Embedded fields due to inline allOf schema
 }
 
@@ -218,19 +197,19 @@ type GetHieraDataParams struct {
 type CreateHieraDataJSONRequestBody NewHieraData
 
 // UpsertHieraDataWithLevelAndKeyJSONRequestBody defines body for UpsertHieraDataWithLevelAndKey for application/json ContentType.
-type UpsertHieraDataWithLevelAndKeyJSONRequestBody EditHieraValue
+type UpsertHieraDataWithLevelAndKeyJSONRequestBody EditableHieraDatumProperties
 
 // CreateNodeJSONRequestBody defines body for CreateNode for application/json ContentType.
 type CreateNodeJSONRequestBody NewNodes
 
 // PutNodeByNameJSONRequestBody defines body for PutNodeByName for application/json ContentType.
-type PutNodeByNameJSONRequestBody NewNode
+type PutNodeByNameJSONRequestBody EditableNodeProperties
 
 // CreateUserJSONRequestBody defines body for CreateUser for application/json ContentType.
 type CreateUserJSONRequestBody NewUsers
 
 // PutUserJSONRequestBody defines body for PutUser for application/json ContentType.
-type PutUserJSONRequestBody NewUser
+type PutUserJSONRequestBody EditableUserProperties
 
 // RequestEditorFn  is the function signature for the RequestEditor callback function
 type RequestEditorFn func(ctx context.Context, req *http.Request) error
@@ -1358,7 +1337,7 @@ type ClientWithResponsesInterface interface {
 type GetHieraDataResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *[]HieraValue
+	JSON200      *[]HieraDatum
 }
 
 // Status returns HTTPResponse.Status
@@ -1380,7 +1359,7 @@ func (r GetHieraDataResponse) StatusCode() int {
 type CreateHieraDataResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON201      *[]HieraValue
+	JSON201      *[]HieraDatum
 }
 
 // Status returns HTTPResponse.Status
@@ -1423,7 +1402,7 @@ func (r DeleteHieraDataObjectResponse) StatusCode() int {
 type GetHieraDataWithLevelAndKeyResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *HieraValue
+	JSON200      *HieraDatum
 }
 
 // Status returns HTTPResponse.Status
@@ -1445,8 +1424,8 @@ func (r GetHieraDataWithLevelAndKeyResponse) StatusCode() int {
 type UpsertHieraDataWithLevelAndKeyResponse struct {
 	Body         []byte
 	HTTPResponse *http.Response
-	JSON200      *HieraValue
-	JSON201      *HieraValue
+	JSON200      *HieraDatum
+	JSON201      *HieraDatum
 }
 
 // Status returns HTTPResponse.Status
@@ -1914,7 +1893,7 @@ func ParseGetHieraDataResponse(rsp *http.Response) (*GetHieraDataResponse, error
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest []HieraValue
+		var dest []HieraDatum
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -1940,7 +1919,7 @@ func ParseCreateHieraDataResponse(rsp *http.Response) (*CreateHieraDataResponse,
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest []HieraValue
+		var dest []HieraDatum
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -1982,7 +1961,7 @@ func ParseGetHieraDataWithLevelAndKeyResponse(rsp *http.Response) (*GetHieraData
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest HieraValue
+		var dest HieraDatum
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
@@ -2008,14 +1987,14 @@ func ParseUpsertHieraDataWithLevelAndKeyResponse(rsp *http.Response) (*UpsertHie
 
 	switch {
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 200:
-		var dest HieraValue
+		var dest HieraDatum
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}
 		response.JSON200 = &dest
 
 	case strings.Contains(rsp.Header.Get("Content-Type"), "json") && rsp.StatusCode == 201:
-		var dest HieraValue
+		var dest HieraDatum
 		if err := json.Unmarshal(bodyBytes, &dest); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The use of "Hiera Datum" replaces use of "Hiera Value" to refer to an individual resource of type Hiera Data. This change is primarily just in the API spec file.

Using Hiera Datum instead of Hiera Value for this avoids potential confusion coming from the fact that a single Hiera Datum resource has a field called "value".

While changing the spec, some other consistency renames got pulled in as well.