### PR TITLE
Attempt to fix POST with differing attributes

### DIFF
--- a/app/lib/pds/model.rb
+++ b/app/lib/pds/model.rb
@@ -1,0 +1,7 @@
+module PDS
+  module Model
+    def property_defaults
+      {}
+    end
+  end
+end

--- a/app/lib/pds/model/hiera_datum.rb
+++ b/app/lib/pds/model/hiera_datum.rb
@@ -1,0 +1,9 @@
+require 'pds/model'
+
+module PDS
+  module Model
+    module HieraDatum
+      include PDS::Model
+    end
+  end
+end

--- a/app/lib/pds/model/node.rb
+++ b/app/lib/pds/model/node.rb
@@ -1,0 +1,13 @@
+require 'pds/model'
+
+module PDS
+  module Model
+    module Node
+      include PDS::Model
+
+      def property_defaults
+        {'classes' => [], 'code-environment' => nil, 'data' => {}}
+      end
+    end
+  end
+end

--- a/app/lib/pds/model/user.rb
+++ b/app/lib/pds/model/user.rb
@@ -1,0 +1,9 @@
+require 'pds/model'
+
+module PDS
+  module Model
+    module User
+      include PDS::Model
+    end
+  end
+end


### PR DESCRIPTION
It was noticed that POST'ing resources with differing attributes wasn't
working. This quick fix attempts to remedy that by assuming that any
missing attributes from one or more resources are valid, and may legally
be null; therefore, explicitly set them to null.