### PR TITLE
freezes gem versions in Gemfile

### DIFF
--- a/app/Gemfile
+++ b/app/Gemfile
@@ -1,11 +1,11 @@
 source 'https://rubygems.org'
 
-gem 'webrick'
+gem 'webrick', '~> 1.7.0'
 gem 'puma', '~> 5.6.2'
-gem 'sinatra'
-gem 'sinatra-cross_origin'
-gem 'sinatra-contrib'
-gem 'committee'
+gem 'sinatra', '~> 2.1.0'
+gem 'sinatra-cross_origin', '~> 0.4.0'
+gem 'sinatra-contrib', '~> 2.1.0'
+gem 'committee', '~> 4.4.0'
 
 gem 'pg', '~> 1.2.3'
 gem 'rake', '~> 13.0.6'

--- a/app/Gemfile
+++ b/app/Gemfile
@@ -1,18 +1,18 @@
 source 'https://rubygems.org'
 
-gem 'webrick', '~> 1.7.0'
-gem 'puma', '~> 5.6.2'
-gem 'sinatra', '~> 2.1.0'
-gem 'sinatra-cross_origin', '~> 0.4.0'
-gem 'sinatra-contrib', '~> 2.1.0'
-gem 'committee', '~> 4.4.0'
+gem 'webrick', '~> 1.7'
+gem 'puma', '~> 5.6'
+gem 'sinatra', '~> 2.1'
+gem 'sinatra-cross_origin', '~> 0.4'
+gem 'sinatra-contrib', '~> 2.1'
+gem 'committee', '~> 4.4'
 
-gem 'pg', '~> 1.2.3'
-gem 'rake', '~> 13.0.6'
-gem 'sinatra-activerecord', '~> 2.0', '>= 2.0.23'
+gem 'pg', '~> 1.2'
+gem 'rake', '~> 13.0'
+gem 'sinatra-activerecord', '~> 2.0'
 
 # activerecord and composite_primary_keys should have paired versions
-gem 'activerecord', '~> 6.1.0'
+gem 'activerecord', '~> 6.1'
 gem 'composite_primary_keys', '~> 13.0'
 
 group :development do

--- a/app/Gemfile
+++ b/app/Gemfile
@@ -1,7 +1,7 @@
 source 'https://rubygems.org'
 
 gem 'webrick'
-gem 'puma'
+gem 'puma', '~> 5.6.2'
 gem 'sinatra'
 gem 'sinatra-cross_origin'
 gem 'sinatra-contrib'

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -63,6 +63,7 @@ GEM
     zeitwerk (2.5.4)
 
 PLATFORMS
+  x86_64-darwin-19
   x86_64-linux
 
 DEPENDENCIES
@@ -71,7 +72,7 @@ DEPENDENCIES
   composite_primary_keys (~> 13.0)
   pg (~> 1.2.3)
   pry
-  puma
+  puma (~> 5.6.2)
   rake (~> 13.0.6)
   sinatra
   sinatra-activerecord (~> 2.0, >= 2.0.23)
@@ -80,4 +81,4 @@ DEPENDENCIES
   webrick
 
 BUNDLED WITH
-   2.3.6
+   2.3.7

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -68,17 +68,17 @@ PLATFORMS
 
 DEPENDENCIES
   activerecord (~> 6.1.0)
-  committee
+  committee (~> 4.4.0)
   composite_primary_keys (~> 13.0)
   pg (~> 1.2.3)
   pry
   puma (~> 5.6.2)
   rake (~> 13.0.6)
-  sinatra
+  sinatra (~> 2.1.0)
   sinatra-activerecord (~> 2.0, >= 2.0.23)
-  sinatra-contrib
-  sinatra-cross_origin
-  webrick
+  sinatra-contrib (~> 2.1.0)
+  sinatra-cross_origin (~> 0.4.0)
+  webrick (~> 1.7.0)
 
 BUNDLED WITH
    2.3.7

--- a/app/Gemfile.lock
+++ b/app/Gemfile.lock
@@ -67,18 +67,18 @@ PLATFORMS
   x86_64-linux
 
 DEPENDENCIES
-  activerecord (~> 6.1.0)
-  committee (~> 4.4.0)
+  activerecord (~> 6.1)
+  committee (~> 4.4)
   composite_primary_keys (~> 13.0)
-  pg (~> 1.2.3)
+  pg (~> 1.2)
   pry
-  puma (~> 5.6.2)
-  rake (~> 13.0.6)
-  sinatra (~> 2.1.0)
-  sinatra-activerecord (~> 2.0, >= 2.0.23)
-  sinatra-contrib (~> 2.1.0)
-  sinatra-cross_origin (~> 0.4.0)
-  webrick (~> 1.7.0)
+  puma (~> 5.6)
+  rake (~> 13.0)
+  sinatra (~> 2.1)
+  sinatra-activerecord (~> 2.0)
+  sinatra-contrib (~> 2.1)
+  sinatra-cross_origin (~> 0.4)
+  webrick (~> 1.7)
 
 BUNDLED WITH
    2.3.7


### PR DESCRIPTION
### Changes

I'm setting the gem versions directly in the Gemfile, this is a good practice to avoid inconveniences in the future when a gem update breaks something in the project.

I tested it manually and the API works fine, no surprises here since the change is just hardcoding the same versions that it using already

----

Related: https://github.com/puppetlabs/puppet-data-service/pull/56
