### PR TITLE
Remove forgotten output

### DIFF
--- a/.github/workflows/release-prep.yaml
+++ b/.github/workflows/release-prep.yaml
@@ -12,8 +12,6 @@ jobs:
   release-prep:
     name: Create release prep PR
     runs-on: ubuntu-latest
-    outputs:
-      versioned_ref: ${{ steps.commit_version.outputs.commit_long_sha }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v2


### PR DESCRIPTION
Removes a job output from the release-pre workflow which is un-used and
left behind from a previous implementation