### PR TITLE
adds a new Rake task to check if an Admin has been created

### DIFF
--- a/app/Rakefile
+++ b/app/Rakefile
@@ -13,16 +13,16 @@ namespace :db do
 end
 
 namespace :app do |args|
+  # Define the helper-required data_adapter method in a way that works for
+  # rake tasks
+  def data_adapter
+    App.settings.data_adapter
+  end
+
   desc "creates and sets an admin token"
   task :set_admin_token, [:token] => :'db:load_config' do |t, args|
     require 'pds/helpers/data_helpers'
     include PDS::Helpers::DataHelpers
-
-    # Define the helper-required data_adapter method in a way that works for
-    # rake tasks
-    def data_adapter
-      App.settings.data_adapter
-    end
 
     admin = {
       'username'   => 'admin',
@@ -33,5 +33,16 @@ namespace :app do |args|
 
     update_timestamps!(:users, [admin])
     data_adapter.upsert(:users, resources: [admin])
+  end
+
+  desc "checks if Admin user exists"
+  task :does_admin_exist do
+    require './app'
+    require 'pds/helpers/data_helpers'
+    include PDS::Helpers::DataHelpers
+
+    users = data_adapter.read(:users, filters: [['=', 'username', 'admin']])
+    abort "Admin does not exist" if users.empty?
+    puts "Admin user exists, created on #{users.first['created-at']}"
   end
 end

--- a/app/Rakefile
+++ b/app/Rakefile
@@ -36,13 +36,21 @@ namespace :app do |args|
   end
 
   desc "checks if Admin user exists"
-  task :does_admin_exist do
+  task :does_admin_exist? do
     require './app'
     require 'pds/helpers/data_helpers'
     include PDS::Helpers::DataHelpers
 
-    users = data_adapter.read(:users, filters: [['=', 'username', 'admin']])
-    abort "Admin does not exist" if users.empty?
-    puts "Admin user exists, created on #{users.first['created-at']}"
+    begin
+      users = data_adapter.read(:users, filters: [['=', 'username', 'admin']])
+      abort "Admin does not exist" if users.empty?
+      puts "Admin user exists, created on #{users.first['created-at']}"
+    rescue ActiveRecord::ConnectionNotEstablished
+      abort "Error: The PDS is not connected to a Database"
+    rescue ActiveRecord::NoDatabaseError
+      abort "Error: The PDS database does not exist, make sure to run 'rake db:create' and 'rake db:migrate' first"
+    rescue ActiveRecord::StatementInvalid, PG::UndefinedTable
+      abort "Error: The PDS is missing one or more tables, make sure to run 'rake db:migrate'"
+    end
   end
 end

--- a/app/Rakefile
+++ b/app/Rakefile
@@ -36,7 +36,7 @@ namespace :app do |args|
   end
 
   desc "checks if Admin user exists"
-  task :does_admin_exist? do
+  task :admin_exists? do
     require './app'
     require 'pds/helpers/data_helpers'
     include PDS::Helpers::DataHelpers

--- a/app/tempBash.sh
+++ b/app/tempBash.sh
@@ -1,0 +1,6 @@
+rake 'app:does_admin_exist?'
+if [ $? -eq 0 ]; then
+    echo OK
+else
+    echo FAIL
+fi

--- a/app/tempBash.sh
+++ b/app/tempBash.sh
@@ -1,6 +1,0 @@
-rake 'app:does_admin_exist?'
-if [ $? -eq 0 ]; then
-    echo OK
-else
-    echo FAIL
-fi


### PR DESCRIPTION
## Changes

I'm adding a new `rake` Task to help us check whether an Admin user has been created.

My intention is to use this new Task in the [PDS module](https://github.com/puppetlabs/puppetlabs-puppet_data_service/pull/7/files) as a condition to create the Admin user:

```
rake app:does_admin_exist
if [ $? -eq 0 ]; then
    echo OK
else
    echo FAIL
fi
```

----

**Bonus:** Since I'm adding the second task under the `:app` namespace, I'm reusing the `data_adapter` method for both tasks