### PR TITLE
Fix ubuntu package build

### DIFF
--- a/.github/actions/create-package-for-el-7/Dockerfile
+++ b/.github/actions/create-package-for-el-7/Dockerfile
@@ -1,13 +1,17 @@
 # Container image that runs your code
 FROM quay.io/centos/centos:7
-RUN \
-  yum -y update ca-certificates && \
-  yum -y install epel-release && \
-  yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm && \
-  yum -y install sudo golang git && \
-  yum -y groupinstall 'Development Tools' && \
-  yum -y clean all && \
-  rm -rf /var/cache
+RUN  yum -y update ca-certificates \
+  && yum -y install epel-release \
+  && yum -y install https://packages.endpointdev.com/rhel/7/os/x86_64/endpoint-repo.x86_64.rpm \
+  && yum -y install sudo git \
+  && yum -y groupinstall 'Development Tools' \
+  && yum -y clean all \
+  && rm -rf /var/cache \
+  && curl -LO https://go.dev/dl/go1.18.1.linux-amd64.tar.gz \
+  && rm -rf /usr/local/go \
+  && tar -C /usr/local -xzf go1.18.1.linux-amd64.tar.gz \
+  && ln -s /usr/local/go/bin/go /usr/bin/go \
+  && rm go1.18.1.linux-amd64.tar.gz
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/.github/actions/create-package-for-el-7/entrypoint.sh
+++ b/.github/actions/create-package-for-el-7/entrypoint.sh
@@ -13,6 +13,9 @@ if [ -z "${PE_VERSION}" ]; then
   exit 1
 fi
 
+# Ensure Git works properly in this GH Actions container environment
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
 # Download PE and install required dependent packages
 
 mkdir -p "${SCRATCHDIR}/pe"

--- a/.github/actions/create-package-for-el-8/Dockerfile
+++ b/.github/actions/create-package-for-el-8/Dockerfile
@@ -1,10 +1,14 @@
 # Container image that runs your code
-FROM quay.io/centos/centos:stream8
-RUN \
-  yum -y groupinstall 'Development Tools' && \
-  yum -y install sudo golang && \
-  yum -y clean all && \
-  rm -rf /var/cache
+FROM almalinux:8
+RUN  yum -y groupinstall 'Development Tools' \
+  && yum -y install git sudo \
+  && yum -y clean all \
+  && rm -rf /var/cache \
+  && curl -LO https://go.dev/dl/go1.18.1.linux-amd64.tar.gz \
+  && rm -rf /usr/local/go \
+  && tar -C /usr/local -xzf go1.18.1.linux-amd64.tar.gz \
+  && ln -s /usr/local/go/bin/go /usr/bin/go \
+  && rm go1.18.1.linux-amd64.tar.gz
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/.github/actions/create-package-for-el-8/entrypoint.sh
+++ b/.github/actions/create-package-for-el-8/entrypoint.sh
@@ -13,6 +13,9 @@ if [ -z "${PE_VERSION}" ]; then
   exit 1
 fi
 
+# Ensure Git works properly in this GH Actions container environment
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
 # Download PE and install required dependent packages
 
 mkdir -p "${SCRATCHDIR}/pe"

--- a/.github/actions/create-package-for-ubuntu-18-04/Dockerfile
+++ b/.github/actions/create-package-for-ubuntu-18-04/Dockerfile
@@ -1,17 +1,24 @@
 # Container image that runs your code
 FROM  ubuntu:18.04
 ENV DEBIAN_FRONTEND noninteractive
-RUN \
-  apt-get update && \
-  apt-get -y install software-properties-common && \
-  apt-get -y install curl && \
-  apt-get -y install make && \
-  apt-get -y install build-essential && \
-  apt-get -y install apt-utils && \
-  apt-get -y install sudo && \
-  add-apt-repository -y ppa:longsleep/golang-backports && \
-  apt-get update && \
-  apt-get -y install golang-go
+RUN  apt-get update \
+  && apt-get -y install \
+       software-properties-common \
+       apt-utils \
+  && add-apt-repository -y ppa:git-core/ppa \
+  && apt-get update \
+  && apt-get -y install \
+       build-essential \
+       curl \
+       git \
+       make \
+       sudo \
+  && rm -rf /var/lib/apt/lists/* \
+  && curl -LO https://go.dev/dl/go1.18.1.linux-amd64.tar.gz \
+  && rm -rf /usr/local/go \
+  && tar -C /usr/local -xzf go1.18.1.linux-amd64.tar.gz \
+  && ln -s /usr/local/go/bin/go /usr/bin/go \
+  && rm go1.18.1.linux-amd64.tar.gz
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh
 

--- a/.github/actions/create-package-for-ubuntu-18-04/entrypoint.sh
+++ b/.github/actions/create-package-for-ubuntu-18-04/entrypoint.sh
@@ -13,6 +13,9 @@ if [ -z "${PE_VERSION}" ]; then
   exit 1
 fi
 
+# Ensure Git works properly in this GH Actions container environment
+git config --global --add safe.directory "$GITHUB_WORKSPACE"
+
 # Download PE and install required dependent packages
 
 mkdir -p "${SCRATCHDIR}/pe"


### PR DESCRIPTION
Seems like golang build needs a newer Git version these days, and (when
running in GitHub CI Actions) a special git config option to be set.

Update all CI images to install go manually.

This also locks Golang to a specific version. Should be greater consistency
between OSes.

Didn't do it for Git yet, but may have to do similar at some point.

Add safe.directory workaround to entrypoint.sh script